### PR TITLE
QA-12608: Create a non escaped HtppClient URI for downloads

### DIFF
--- a/core/src/main/java/org/jahia/modules/modulemanager/forge/ForgeService.java
+++ b/core/src/main/java/org/jahia/modules/modulemanager/forge/ForgeService.java
@@ -44,6 +44,8 @@
 package org.jahia.modules.modulemanager.forge;
 
 import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
@@ -70,6 +72,9 @@ import javax.jcr.RepositoryException;
 import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.*;
 
 /**
@@ -290,7 +295,13 @@ public class ForgeService {
     public File downloadModuleFromForge(String forgeId, String url) {
         for (Forge forge : forges) {
             if (forgeId.equals(forge.getId())) {
-                GetMethod httpMethod = new GetMethod(url);
+                GetMethod httpMethod = new GetMethod();
+                try {
+                    httpMethod.setURI(new URI(url, false, "UTF-8"));
+                } catch (URIException e) {
+                    logger.error(e.getMessage(),e);
+                    return null;
+                }
                 httpMethod.addRequestHeader("Authorization", "Basic " + Base64.encode((forge.getUser() + ":" + forge.getPassword()).getBytes()));
                 HttpClient httpClient = httpClientService.getHttpClient(url);
                 try {


### PR DESCRIPTION


<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-12608

## Description

Create a non escaped HtppClient URI for downloading forge modules, this allow to download paths with special characters.

Once merged we can see how to port this for 7.3.X

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [X] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [X] Performance
- [X] Migration
- [X] Code maintainability