### PR TITLE
QA-14336: Fix validation error when deleting forge

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -33,7 +33,7 @@
         <jahia-module-type>system</jahia-module-type>
         <jahia-deploy-on-site>system</jahia-deploy-on-site>
         <export-package>org.jahia.modules.modulemanager.forge</export-package>
-        <jahia-module-signature>MC4CFQCBJy4mD7nrTq3vYBgKlmfjUOAlcwIVAJVTBGLJKOVqeDKfEfrx1Nj3BxWY</jahia-module-signature>
+        <jahia-module-signature>MCwCFF5ekcLPfybu1RqG/kDByw/YbkV5AhQwA5/gL7H9ObQNQ67Q1EfQRja8xQ==</jahia-module-signature>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
         <yarn.arguments>build:production</yarn.arguments>
         <jahia.plugin.version>6.1</jahia.plugin.version>

--- a/core/src/main/java/org/jahia/modules/modulemanager/forge/Forge.java
+++ b/core/src/main/java/org/jahia/modules/modulemanager/forge/Forge.java
@@ -37,6 +37,15 @@ public class Forge implements Serializable {
     String user;
     String password;
     String id;
+    String actionType;
+
+    public String getActionType() {
+        return actionType;
+    }
+
+    public void setActionType(String actionType) {
+        this.actionType = actionType;
+    }
 
     public String getUrl() {
         return url;

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     </scm>
 
     <properties>
-        <jahia-module-signature>MCwCFBpmMLYm3lxzw6AYzp32SJcKHgFSAhQGGGvjfrWDMFcHmaS/hjc+kuBtiw==</jahia-module-signature>
+        <jahia-module-signature>MCwCFGOEpQAs3Mm77ZNzE0158T9rIUUSAhRuQPoUkvYWIckwy29aXoCz0x1IgA==</jahia-module-signature>
     </properties>
 
     <repositories>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <jahia-depends>module-manager</jahia-depends>
         <jahia-module-type>system</jahia-module-type>
-        <jahia-module-signature>MCwCFEdpYYrI1cwtg1yruzQIuXr/7jQCAhQauPVLyZAyjdUr9RiEVo+3h/inzw==</jahia-module-signature>
+        <jahia-module-signature>MC4CFQCFJQIoVeRWEMWze/ga7RZPyqNaFgIVAJG3ljjCtLuWk044TTGpVJ6FJRBI</jahia-module-signature>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
     </properties>
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-14336

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

There is currently a check to skip validation on delete (see [here](https://github.com/Jahia/module-manager/blob/master/core/src/main/java/org/jahia/modules/modulemanager/forge/Forge.java#L74)) but is being bypassed. This is then causing a validation error when trying to delete a forge, preventing the delete.

The check is bypassed because `actionType` parameter is missing from the context. Adding getter/setter methods lets spring web flow populate the context parameter value which fixes the issue.
