### PR TITLE
BACKLOG-19914: Disable module operations through configuration

### DIFF
--- a/core/src/main/java/org/jahia/modules/modulemanager/configuration/OperationConstraint.java
+++ b/core/src/main/java/org/jahia/modules/modulemanager/configuration/OperationConstraint.java
@@ -1,0 +1,125 @@
+package org.jahia.modules.modulemanager.configuration;
+
+import org.apache.commons.lang3.EnumUtils;
+import org.jahia.services.modulemanager.util.PropertiesList;
+import org.jahia.services.modulemanager.util.PropertiesValues;
+import org.osgi.framework.Version;
+import org.osgi.framework.VersionRange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Instance of an operation constraint defined within the 'moduleLifeCycleConstraints' configuration
+ * Optional parameters include version range and specific operations to disable
+ *
+ * If versionRange is not found, then constraint is applied to all versions of the module
+ * If disableOperations is blank, then all operations are not allowed
+ */
+public class OperationConstraint {
+
+    private static final Logger logger = LoggerFactory.getLogger(OperationConstraint.class);
+
+    private final String moduleId;
+    private VersionRange versionRange = null;
+    private final Set<Operation> disableOperations = new HashSet<>();
+    private final String pid;
+
+    enum Operation {DEPLOY, UNDEPLOY, STOP, START};
+
+
+    public OperationConstraint(String pid, String moduleId) {
+        this.pid = pid;
+        this.moduleId = moduleId;
+    }
+
+    public static OperationConstraint parse(String pid, PropertiesValues constraintConfig) {
+        // parse moduleId
+        String moduleId = constraintConfig.getProperty("moduleId");
+        if (moduleId == null) {
+            return null;
+        }
+        OperationConstraint constraint = new OperationConstraint(pid, moduleId);
+
+        // parse version
+        String vrStr = constraintConfig.getProperty("version");
+        constraint.setVersionRange(vrStr);
+
+        // parse constraints
+        PropertiesList ops = constraintConfig.getList("disableOperations");
+        for (int i = 0; i < ops.getSize(); i++) {
+            String op = ops.getProperty(i);
+            constraint.addOperation(op);
+        }
+        // if no operations, add all
+        if (!constraint.hasOperations()) {
+            Arrays.stream(Operation.values()).forEach(constraint::addOperation);
+        }
+
+        return constraint;
+    }
+
+    public String getModuleId() {
+        return moduleId;
+    }
+
+    public String getPid() {
+        return pid;
+    }
+
+    /**
+     * Set/parse version range for this constraint, or null (all version) if it cannot be parsed
+     * @param versionRange
+     */
+    public void setVersionRange(String versionRange) {
+        VersionRange vr = null;
+        try {
+            vr = (versionRange == null) ? null : VersionRange.valueOf(versionRange);
+        } catch (Exception e) {
+            logger.warn("Unable to parse version range for module {}: {}", this.moduleId, versionRange);
+        }
+        this.versionRange = vr;
+    }
+
+    public void addOperation(String op) {
+        Operation o = EnumUtils.getEnum(Operation.class, op);
+        addOperation(o);
+        if (o == null) {
+            logger.warn("Skipping invalid operation constraint for module {} : {}", this.moduleId, op);
+        }
+    }
+
+    public void addOperation(Operation op) {
+        if (op != null) {
+            disableOperations.add(op);
+        }
+    }
+
+    public boolean hasOperations() {
+        return !disableOperations.isEmpty();
+    }
+
+    public boolean inRange(Version v) {
+        return (versionRange == null) || versionRange.includes(v);
+    }
+
+    public boolean canDeploy() {
+        return !disableOperations.contains(Operation.DEPLOY);
+    }
+
+    public boolean canUndeploy() {
+        return !disableOperations.contains(Operation.UNDEPLOY);
+    }
+
+    public boolean canStop() {
+        return !disableOperations.contains(Operation.STOP);
+    }
+
+    public boolean canStart() {
+        return !disableOperations.contains(Operation.START);
+    }
+
+}

--- a/core/src/main/java/org/jahia/modules/modulemanager/configuration/OperationConstraints.java
+++ b/core/src/main/java/org/jahia/modules/modulemanager/configuration/OperationConstraints.java
@@ -1,0 +1,80 @@
+/*
+ * ==========================================================================================
+ * =                            JAHIA'S ENTERPRISE DISTRIBUTION                             =
+ * ==========================================================================================
+ *
+ *                                  http://www.jahia.com
+ *
+ * JAHIA'S ENTERPRISE DISTRIBUTIONS LICENSING - IMPORTANT INFORMATION
+ * ==========================================================================================
+ *
+ *     Copyright (C) 2002-2022 Jahia Solutions Group. All rights reserved.
+ *
+ *     This file is part of a Jahia's Enterprise Distribution.
+ *
+ *     Jahia's Enterprise Distributions must be used in accordance with the terms
+ *     contained in the Jahia Solutions Group Terms &amp; Conditions as well as
+ *     the Jahia Sustainable Enterprise License (JSEL).
+ *
+ *     For questions regarding licensing, support, production usage...
+ *     please contact our team at sales@jahia.com or go to http://www.jahia.com/license.
+ *
+ * ==========================================================================================
+ */
+package org.jahia.modules.modulemanager.configuration;
+
+import org.apache.commons.lang3.StringUtils;
+import org.osgi.framework.Version;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Wrapper object representing collection of <code>OperationConstraint</code>s for each given pid
+ *
+ * @author gflores
+ */
+public class OperationConstraints {
+
+    Map<String, OperationConstraint> ops = Collections.synchronizedMap(new HashMap<>());
+
+    /**
+     * @param o Add to list of OperationConstraint.
+     * Do nothing if it already exists i.e. need to remove first before adding.
+     */
+    public void add(OperationConstraint o) {
+        ops.putIfAbsent(o.getPid(), o);
+    }
+
+    public void remove(String pid) {
+        ops.remove(pid);
+    }
+
+    public boolean isEmpty() {
+        return ops.isEmpty();
+    }
+
+    public boolean inRange(Version v) {
+        return ops.values().stream().anyMatch(o -> o.inRange(v));
+    }
+
+    public boolean canDeploy(Version v) {
+        return ops.values().stream()
+                .allMatch(o -> !o.inRange(v) || o.canDeploy());
+    }
+
+    public boolean canUndeploy(Version v) {
+        return ops.values().stream()
+            .allMatch(o -> !o.inRange(v) || o.canUndeploy());
+    }
+
+    public boolean canStop(Version v) {
+        return ops.values().stream()
+                .allMatch(o -> !o.inRange(v) || o.canStop());
+    }
+
+    public boolean canStart(Version v) {
+        return ops.values().stream()
+                .allMatch(o -> !o.inRange(v) || o.canStart());
+    }
+}

--- a/core/src/main/java/org/jahia/modules/modulemanager/configuration/OperationConstraintsService.java
+++ b/core/src/main/java/org/jahia/modules/modulemanager/configuration/OperationConstraintsService.java
@@ -1,0 +1,10 @@
+package org.jahia.modules.modulemanager.configuration;
+
+import org.osgi.framework.Bundle;
+
+/**
+ * Service for processing operation constraints specified through configuration
+ */
+public interface OperationConstraintsService {
+    OperationConstraint getConstraintForBundle(Bundle bundle);
+}

--- a/core/src/main/java/org/jahia/modules/modulemanager/configuration/OperationConstraintsService.java
+++ b/core/src/main/java/org/jahia/modules/modulemanager/configuration/OperationConstraintsService.java
@@ -6,5 +6,5 @@ import org.osgi.framework.Bundle;
  * Service for processing operation constraints specified through configuration
  */
 public interface OperationConstraintsService {
-    OperationConstraint getConstraintForBundle(Bundle bundle);
+    OperationConstraints getConstraintForBundle(Bundle bundle);
 }

--- a/core/src/main/java/org/jahia/modules/modulemanager/configuration/OperationConstraintsServiceImpl.java
+++ b/core/src/main/java/org/jahia/modules/modulemanager/configuration/OperationConstraintsServiceImpl.java
@@ -1,0 +1,104 @@
+/*
+ * ==========================================================================================
+ * =                            JAHIA'S ENTERPRISE DISTRIBUTION                             =
+ * ==========================================================================================
+ *
+ *                                  http://www.jahia.com
+ *
+ * JAHIA'S ENTERPRISE DISTRIBUTIONS LICENSING - IMPORTANT INFORMATION
+ * ==========================================================================================
+ *
+ *     Copyright (C) 2002-2022 Jahia Solutions Group. All rights reserved.
+ *
+ *     This file is part of a Jahia's Enterprise Distribution.
+ *
+ *     Jahia's Enterprise Distributions must be used in accordance with the terms
+ *     contained in the Jahia Solutions Group Terms &amp; Conditions as well as
+ *     the Jahia Sustainable Enterprise License (JSEL).
+ *
+ *     For questions regarding licensing, support, production usage...
+ *     please contact our team at sales@jahia.com or go to http://www.jahia.com/license.
+ *
+ * ==========================================================================================
+ */
+package org.jahia.modules.modulemanager.configuration;
+
+import org.jahia.services.modulemanager.util.PropertiesList;
+import org.jahia.services.modulemanager.util.PropertiesManager;
+import org.jahia.services.modulemanager.util.PropertiesValues;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.Version;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Component(
+        service = OperationConstraintsService.class,
+        immediate = true,
+        name = "org.jahia.modules.modulemanager.configuration.constraints"
+)
+public class OperationConstraintsServiceImpl implements OperationConstraintsService {
+
+    private static final Logger logger = LoggerFactory.getLogger(OperationConstraintsServiceImpl.class);
+    private static final String CONSTRAINTS_CONFIG_KEY = "moduleLifeCycleConstraints";
+
+    private static final Map<String, OperationConstraint> constraints = new HashMap<>();
+
+    @Activate
+    public void activate(Map<String, String> props) {
+        logger.debug("Activating configuration service");
+        clearConstraintsByPid(props.get("service.pid"));
+        parseConfig(props);
+    }
+
+    /**
+     * Add constraint to list of definitions.
+     * Replace constraint if it exists.
+     */
+    private void parseConfig(Map<String, String> props) {
+        logger.debug("Parsing configuration property values");
+        String pid = props.get("service.pid");
+        PropertiesManager pm = new PropertiesManager(props);
+        PropertiesList constraintsProp = pm.getValues().getList(CONSTRAINTS_CONFIG_KEY);
+        for (int i = 0; i < constraintsProp.getSize(); i++) {
+            PropertiesValues constraintProp = constraintsProp.getValues(i);
+            OperationConstraint constraint = OperationConstraint.parse(pid, constraintProp);
+            if (constraint != null) {
+                constraints.put(constraint.getModuleId(), constraint);
+            }
+        }
+        logger.debug("Configuration parsed");
+    }
+
+    @Modified
+    public void modified(Map<String,String> props) {
+        String pid = props.get("service.pid");
+        logger.debug("Updating configuration {}...", pid);
+        clearConstraintsByPid(pid);
+        parseConfig(props);
+        logger.debug("Configuration updated.");
+    }
+
+    private void clearConstraintsByPid(String pid) {
+        if (pid != null) {
+            Set<String> moduleIds = constraints.entrySet().stream()
+                    .filter(c -> c.getValue().getPid().equals(pid))
+                    .map(Map.Entry::getKey)
+                    .collect(Collectors.toSet());
+            constraints.keySet().removeAll(moduleIds);
+        }
+    }
+
+    public OperationConstraint getConstraintForBundle(Bundle b) {
+        String moduleId = b.getSymbolicName();
+        Version version = b.getVersion();
+
+        OperationConstraint c = constraints.get(moduleId);
+        return (c != null && c.inRange(version)) ? c : null;
+    }
+}

--- a/core/src/main/java/org/jahia/modules/modulemanager/configuration/README.md
+++ b/core/src/main/java/org/jahia/modules/modulemanager/configuration/README.md
@@ -23,7 +23,6 @@ moduleLifeCycleConstraints:
   - moduleId: "bookmarks"
     disableOperations: [START, DEPLOY]
     version: "[4,5.2]"
-
 ```
 
 ### *cfg format*
@@ -55,10 +54,27 @@ moduleLifeCycleConstraints[1].disableOperations[1]="DEPLOY"
     * DEPLOY
   * Defaults to ***all*** operations disabled if not specified or given an empty list
 
-## Implementation notes/questions
+### Duplicate definitions
 
-* Do we need to worry about overriding default config file? I'm not sure if there's a way to protect that. Or safe to assume we're not going to override default config?
-* (Maybe for @tdraier) Constraint checks already in the module manager UI but need more work on the deployment scenario specifically for certain versions (to be implemented)
-* Do we need to handle priority? What happens when constraints are defined in more than one configuration?
-  * Currently latest edits overwrite old defintions but maybe we can keep track of them separately and apply them with logical AND (apply all rules). Or not sure if safe to assume no conflicts for now.
-* * I'm assuming configuration deployment applies to all nodes in a cluster (to be tested)?
+Duplicate definitions across different configurations for a given module ID are all applied individually. e.g. given the following rules from different configuration files:
+
+```
+moduleLifeCycleConstraints:
+  - moduleId: "my-module"
+    version: 3
+    disableOperations:
+      - STOP
+```
+
+and 
+
+```
+moduleLifeCycleConstraints:
+  - moduleId: "my-module"
+    version: 4
+    disableOperations:
+      - START
+```
+
+Then `module@v3.0.0` will only have STOP operation disabled and `module@v4.0.0` will only have START operation disabled (rules are applied individually and not merged).
+

--- a/core/src/main/java/org/jahia/modules/modulemanager/configuration/README.md
+++ b/core/src/main/java/org/jahia/modules/modulemanager/configuration/README.md
@@ -1,0 +1,64 @@
+# Disable operations per module
+
+* Disable certain module management functions through configuration: `org.jahia.modules.modulemanager.configuration.constraints-*.yaml/cfg`
+* Default set of restrictions included in the `module-manager` module deployed: `org.jahia.modules.modulemanager.configuration.constraints-default.yaml`
+* Constraints can be extended by deploying another configuration e.g. `org.jahia.modules.modulemanager.configuration.constraints-cloud.yaml/cfg`
+* To update, simply re-deploy same configuration file with the changes. This will refresh all previous definitions for a given configuration file.
+
+## Deployment
+
+ * Supports standard configuration deployment options
+   * Through provisioning (see [Provisioning - Install/edit configuration](https://github.com/Jahia/jahia/tree/master/bundles/provisioning#install--edit-configuration))
+   * Manual deploy in `karaf/etc` folder
+
+## Format
+
+### *yaml format*
+
+```
+moduleLifeCycleConstraints:
+  - moduleId: "article"
+    disableOperations:
+      - STOP
+  - moduleId: "bookmarks"
+    disableOperations: [START, DEPLOY]
+    version: "[4,5.2]"
+
+```
+
+### *cfg format*
+
+```
+moduleLifeCycleConstraints[0].moduleId=article
+moduleLifeCycleConstraints[0].disableOperations[0]=STOP
+
+moduleLifeCycleConstraints[1].moduleId="bookmarks"
+moduleLifeCycleConstraints[1].version="[4,5.2]"
+moduleLifeCycleConstraints[1].disableOperations[0]="START"
+moduleLifeCycleConstraints[1].disableOperations[1]="DEPLOY"
+```
+
+### Attribute definitions
+
+* **moduleId** (required) - module name
+* **version** (optional) - Specific version to which constraint should apply to for a specific module.
+  * Supports semantic versioning
+    * e.g. `version: 3` means constraint applies for all `3.x.x` versions only
+  * Supports standard OSGI version ranges
+    * e.g. `[3.1, 4)` constraint applies to module versions between `3.1.x` (inclusive) up to `4.0` (exclusive)
+  * Constraint applies to all versions of the module if not specified
+* **disableOperations** (optional) - List of operations to be disabled for a given module/version
+  * Current list of operations to be restricted (case-sensitive)
+    * START
+    * STOP
+    * UNDEPLOY
+    * DEPLOY
+  * Defaults to ***all*** operations disabled if not specified or given an empty list
+
+## Implementation notes/questions
+
+* Do we need to worry about overriding default config file? I'm not sure if there's a way to protect that. Or safe to assume we're not going to override default config?
+* (Maybe for @tdraier) Constraint checks already in the module manager UI but need more work on the deployment scenario specifically for certain versions (to be implemented)
+* Do we need to handle priority? What happens when constraints are defined in more than one configuration?
+  * Currently latest edits overwrite old defintions but maybe we can keep track of them separately and apply them with logical AND (apply all rules). Or not sure if safe to assume no conflicts for now.
+* * I'm assuming configuration deployment applies to all nodes in a cluster (to be tested)?

--- a/core/src/main/java/org/jahia/modules/modulemanager/flow/ModuleManagementFlowHandler.java
+++ b/core/src/main/java/org/jahia/modules/modulemanager/flow/ModuleManagementFlowHandler.java
@@ -29,7 +29,7 @@ import org.jahia.data.templates.ModuleState;
 import org.jahia.data.templates.ModuleState.State;
 import org.jahia.data.templates.ModulesPackage;
 import org.jahia.exceptions.JahiaException;
-import org.jahia.modules.modulemanager.configuration.OperationConstraint;
+import org.jahia.modules.modulemanager.configuration.OperationConstraints;
 import org.jahia.modules.modulemanager.configuration.OperationConstraintsService;
 import org.jahia.modules.modulemanager.forge.ForgeService;
 import org.jahia.modules.modulemanager.forge.Module;
@@ -694,12 +694,13 @@ public class ModuleManagementFlowHandler implements Serializable {
                 moduleVersions.put(moduleVersionEntry.getKey(), state);
 
                 Bundle b = moduleVersionEntry.getValue().getBundle();
-                OperationConstraint op = opConstraintService.getConstraintForBundle(b);
-                if (op != null) {
-                    state.setCanBeStarted(state.isCanBeStarted() && op.canStart());
-                    state.setCanBeStopped(state.isCanBeStopped() && op.canStop());
-                    state.setCanBeUninstalled(state.isCanBeUninstalled() && op.canUndeploy());
-                    state.setCanBeReinstalled(state.isCanBeReinstalled() && op.canDeploy());
+                OperationConstraints ops = opConstraintService.getConstraintForBundle(b);
+                if (ops != null) {
+                    org.osgi.framework.Version v = b.getVersion();
+                    state.setCanBeStarted(state.isCanBeStarted() && ops.canStart(v));
+                    state.setCanBeStopped(state.isCanBeStopped() && ops.canStop(v));
+                    state.setCanBeUninstalled(state.isCanBeUninstalled() && ops.canUndeploy(v));
+                    state.setCanBeReinstalled(state.isCanBeReinstalled() && ops.canDeploy(v));
                 }
             }
 

--- a/core/src/main/resources/META-INF/configurations/org.jahia.modules.modulemanager.configuration.constraints-default.yaml
+++ b/core/src/main/resources/META-INF/configurations/org.jahia.modules.modulemanager.configuration.constraints-default.yaml
@@ -1,7 +1,17 @@
 moduleLifeCycleConstraints:
-  - moduleId: "article"
-    disableOperations:
-      - STOP
-  - moduleId: "bookmarks"
-    disableOperations: [START, DEPLOY]
-    version: "[4,5]"
+  - moduleId: "content-editor"
+    disableOperations: [STOP]
+  - moduleId: "graphql-dxm-provider"
+    disableOperations: [STOP]
+  - moduleId: "jcontent"
+    disableOperations: [STOP]
+  - moduleId: "jahia-dashboard"
+    disableOperations: [STOP]
+  - moduleId: "jahia-page-composer"
+    disableOperations: [STOP]
+  - moduleId: "jcrestapi"
+    disableOperations: [STOP]
+  - moduleId: "rolesmanager"
+    disableOperations: [STOP]
+  - moduleId: "tools"
+    disableOperations: [STOP]

--- a/core/src/main/resources/META-INF/configurations/org.jahia.modules.modulemanager.configuration.constraints-default.yaml
+++ b/core/src/main/resources/META-INF/configurations/org.jahia.modules.modulemanager.configuration.constraints-default.yaml
@@ -1,0 +1,7 @@
+moduleLifeCycleConstraints:
+  - moduleId: "article"
+    disableOperations:
+      - STOP
+  - moduleId: "bookmarks"
+    disableOperations: [START, DEPLOY]
+    version: "[4,5]"


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-19914

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

* Add configuration service to handle parsing and managing constraints
* Disable operations in module administration view (restricting deploy TBD)