### PR TITLE
fixed typo in german properties file

### DIFF
--- a/core/src/main/resources/resources/ModuleManager_de.properties
+++ b/core/src/main/resources/resources/ModuleManager_de.properties
@@ -81,7 +81,7 @@ serverSettings.manageModules.module.state.error_with_rules=Ungültige Geschäftsre
 serverSettings.manageModules.module.state.inactive=Inaktiv
 serverSettings.manageModules.module.state.incompatible_version=Inkompatible Version
 serverSettings.manageModules.module.state.installed=Installiert
-erverSettings.manageModules.module.state.multipleVersions.development=Mehrere bereitgestellte Versionen eines Moduls können zu Konflikten führen. <a href="{0}">Weitere Informationen.</a>
+serverSettings.manageModules.module.state.multipleVersions.development=Mehrere bereitgestellte Versionen eines Moduls können zu Konflikten führen. <a href="{0}">Weitere Informationen.</a>
 serverSettings.manageModules.module.state.multipleVersions.production=Um Konflikte zu vermeiden, entfernen Sie bitte ungenutzte Modul-Versionen, um nur die gestarteten zu behalten. <a href="{0}">Weitere Informationen.</a>
 serverSettings.manageModules.module.state.resolved=Aufgelöst
 serverSettings.manageModules.module.state.spring_not_started=Spring nicht gestartet


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-20206

## Description

Fixed typo - we were missing a "s" to _serverSettings.manageModules.module.state.multipleVersions.development_ property.