### PR TITLE
TECH-1132: Enable start button for module with unresolved optional dependency

### DIFF
--- a/core/src/main/java/org/jahia/modules/modulemanager/flow/ModuleManagementFlowHandler.java
+++ b/core/src/main/java/org/jahia/modules/modulemanager/flow/ModuleManagementFlowHandler.java
@@ -785,8 +785,10 @@ public class ModuleManagementFlowHandler implements Serializable {
         }
 
         for (JahiaDepends d : pkg.getVersionDepends()) {
-            JahiaTemplatesPackage p = templateManagerService.getAnyDeployedTemplatePackage(d.toString());
-            if (p == null) state.getUnresolvedDependencies().add(d.toString());
+            if (!d.isOptional()) {
+                JahiaTemplatesPackage p = templateManagerService.getAnyDeployedTemplatePackage(d.getModuleName());
+                if (p == null) state.getUnresolvedDependencies().add(d.toString());
+            }
         }
 
         List<JahiaTemplatesPackage> dependantModules = registry.getDependantModules(pkg);


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/TECH-1132

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Exclude optional dependencies when checking for unresolved dependencies info, which was preventing start button to be enabled.