### PR TITLE
BACKLOG-20603: Fix regression on parsing dependency

### DIFF
--- a/core/src/main/java/org/jahia/modules/modulemanager/flow/ModuleManagementFlowHandler.java
+++ b/core/src/main/java/org/jahia/modules/modulemanager/flow/ModuleManagementFlowHandler.java
@@ -786,7 +786,7 @@ public class ModuleManagementFlowHandler implements Serializable {
 
         for (JahiaDepends d : pkg.getVersionDepends()) {
             if (!d.isOptional()) {
-                JahiaTemplatesPackage p = templateManagerService.getAnyDeployedTemplatePackage(d.getModuleName());
+                JahiaTemplatesPackage p = templateManagerService.getAnyDeployedTemplatePackage(d.toString());
                 if (p == null) state.getUnresolvedDependencies().add(d.toString());
             }
         }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20603

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Revert change from https://github.com/Jahia/module-manager/pull/96 back to passing full dependency string instead of just module name