### PR TITLE
Update Jahia module signature for version 2.10.0-SNAPSHOT

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -33,7 +33,7 @@
         <jahia-module-type>system</jahia-module-type>
         <jahia-deploy-on-site>system</jahia-deploy-on-site>
         <export-package>org.jahia.modules.modulemanager.forge</export-package>
-        <jahia-module-signature>MC0CFQCGdr31QtjwWQvpvNZovvLwuUdCagIUZTXknVJkB7IEZbZhjJXqFX8SoHQ=</jahia-module-signature>
+        <jahia-module-signature>MCwCFH75+4tGbwBQimQTfFwFe8oQY2VmAhQkcVzXKFyjUDdwZbGWuD3zkqkwKQ==</jahia-module-signature>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
         <yarn.arguments>build:production</yarn.arguments>
         <sonar.sources>src/javascript,src/main/resources/javascript</sonar.sources>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -32,7 +32,6 @@
     <properties>
         <jahia-depends>module-manager</jahia-depends>
         <jahia-module-type>system</jahia-module-type>
-        <jahia-module-signature>MCwCFH/8819KLc3YJ6NCaLCCMqz7Os5pAhROgxDgJbCsTNbqb4N+uWHLLA3H5A==</jahia-module-signature>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
     </properties>
 


### PR DESCRIPTION

## Description

Update the module signature for the new version (2.10.0-SNAPSHOT).
Also remove the signature for the test module as it does not require a signature (because its `groupId` is `org.jahia.test`)

