### PR TITLE
BACKLOG-23536: Improve error message when JS Engine is missing

### DIFF
--- a/core/src/main/java/org/jahia/modules/modulemanager/flow/ModuleManagementFlowHandler.java
+++ b/core/src/main/java/org/jahia/modules/modulemanager/flow/ModuleManagementFlowHandler.java
@@ -174,7 +174,8 @@ public class ModuleManagementFlowHandler implements Serializable {
 
     private boolean handleModule(File file, MessageContext context, String originalFilename, boolean forceUpdate, boolean autoStart, boolean ignoreChecks) {
         try {
-            boolean canHandleExtension = FilenameUtils.isExtension(StringUtils.lowerCase(originalFilename), "jar");
+            String fileNameLoweredCase = StringUtils.lowerCase(originalFilename);
+            boolean canHandleExtension = FilenameUtils.isExtension(fileNameLoweredCase, "jar");
             //If it cannot be handled as Jar, look for impl that can handle this extension
             if (!canHandleExtension) {
                 BundleContext bundleContext = FrameworkService.getBundleContext();
@@ -197,8 +198,16 @@ public class ModuleManagementFlowHandler implements Serializable {
 
             //If it is not a jar and none impl can handle this extension
             if (!canHandleExtension) {
-                context.addMessage(new MessageBuilder().error().source("moduleFile")
-                        .code("serverSettings.manageModules.install.wrongFormat").build());
+                MessageBuilder moduleFileMsgBuilder = new MessageBuilder().error().source("moduleFile");
+                // Use a custom error message for tgz files when no Javascript Modules Engine is installed
+                if (FilenameUtils.isExtension(fileNameLoweredCase, "tgz")) {
+                    context.addMessage(moduleFileMsgBuilder
+                            .code("serverSettings.manageModules.install.missingJavascriptEngine").build());
+                } else {
+                    context.addMessage(moduleFileMsgBuilder
+                            .code("serverSettings.manageModules.install.wrongFormat").build());
+                }
+
                 return false;
             }
 

--- a/core/src/main/resources/resources/ModuleManager_de.properties
+++ b/core/src/main/resources/resources/ModuleManager_de.properties
@@ -36,6 +36,7 @@ serverSettings.manageModules.install.uploadedAndStarted=Modul {0} ({1}) wurde er
 serverSettings.manageModules.install.uploadedAndStarted.bundle=Bundle {0} ({1}) wurde erfolgreich hochgeladen und gestartet.
 serverSettings.manageModules.install.uploadedNotStartedDueToNewerVersionActive=Modul {0} ({1}) wurde erfolgreich hochgeladen, aber nicht gestartet da eine aktuellere Version dieses Moduls derzeit aktiv ist.
 serverSettings.manageModules.install.waitingToBeImported=Modul {0} ({1}) wird auf allen Cluster-Knoten deployed. Bitte warten Sie bis diese Operation beendet wurde und überprüfen Sie den Status in der Liste.
+serverSettings.manageModules.install.missingJavascriptEngine=Dieses Modul kann nicht installiert werden. Bitte installieren und starten Sie zuerst die Javascript Modules Engine.
 serverSettings.manageModules.install.wrongFormat=Die hochgeladene Datei ist kein gültiges Jahia Modul.
 serverSettings.manageModules.installedModules=Installierte Module
 serverSettings.manageModules.lastUpdate=Letztes Update

--- a/core/src/main/resources/resources/ModuleManager_en.properties
+++ b/core/src/main/resources/resources/ModuleManager_en.properties
@@ -47,6 +47,7 @@ serverSettings.manageModules.install.uploadedAndStarted=Module {0} ({1}) has bee
 serverSettings.manageModules.install.uploadedAndStarted.bundle=Bundle {0} ({1}) has been successfully uploaded and started.
 serverSettings.manageModules.install.uploadedNotStartedDueToNewerVersionActive=Module {0} ({1}) has been successfully uploaded, however not started due to its newer version currently active. Please check its status in the list.
 serverSettings.manageModules.install.waitingToBeImported=Module {0} ({1}) is being deployed on all cluster nodes. Please, wait until the completion of that operation and check its status in the list.
+serverSettings.manageModules.install.missingJavascriptEngine=Unable to install this module. Please install and start the Javascript Modules Engine first.
 serverSettings.manageModules.install.wrongFormat=The uploaded file is not a valid Jahia module.
 serverSettings.manageModules.installedModules=Installed modules
 serverSettings.manageModules.lastUpdate=Last update

--- a/core/src/main/resources/resources/ModuleManager_fr.properties
+++ b/core/src/main/resources/resources/ModuleManager_fr.properties
@@ -47,6 +47,7 @@ serverSettings.manageModules.install.uploadedAndStarted=Le module {0} ({1}) a ét
 serverSettings.manageModules.install.uploadedAndStarted.bundle=Le bundle {0} ({1}) a été correctement envoyé sur le serveur et demarré.
 serverSettings.manageModules.install.uploadedNotStartedDueToNewerVersionActive=Le module {0} ({1}) a été correctement envoyé sur le serveur mais n'est pas démarré car une version plus récente est déjà active.
 serverSettings.manageModules.install.waitingToBeImported=Le module {0} ({1}) est en cours de déploiement sur tous les membres du cluster. Merci d'attendre la fin de cette opération avant de vérifier son statut dans la liste.
+serverSettings.manageModules.install.missingJavascriptEngine=Impossible d'installer ce module. Merci d'installer et de démarrer le Javascript Modules Engine au préalable.
 serverSettings.manageModules.install.wrongFormat=Le fichier uploadé n'est pas un module Jahia valide.
 serverSettings.manageModules.installedModules=Modules installés
 serverSettings.manageModules.lastUpdate=Dernière mise à jour


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-23536

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

Improve the error message when trying to install a tgz file (very likely a Javascript modules) but the _Javascript Modules Engine_ is not installed/running:
<img width="923" alt="image" src="https://github.com/user-attachments/assets/e925ffcc-6d00-4bdd-a972-46b1898aada6" />
