### PR TITLE
docs: change label when module is stopped. This apply to javascript-mo…

### DIFF
--- a/core/src/main/resources/resources/ModuleManager_en.properties
+++ b/core/src/main/resources/resources/ModuleManager_en.properties
@@ -106,7 +106,7 @@ serverSettings.manageModules.module.state.starting=Starting
 serverSettings.manageModules.module.state.stopping=Stopping
 serverSettings.manageModules.module.state.updated=Updated
 serverSettings.manageModules.module.state.waiting_to_be_imported=Waiting to be imported
-serverSettings.manageModules.module.stopped=Module {0} has been stopped.<br/><span style="font-size: 15px; font-weight: bold;">Live rendering for that module will be available if not in cache or when cache has expired.</span>
+serverSettings.manageModules.module.stopped=Module {0} has been stopped.<br/><span style="font-size: 15px; font-weight: bold;">Live rendering for that module will not be available if not in cache or when cache has expired.</span>
 serverSettings.manageModules.module.type=Module Type
 serverSettings.manageModules.module.undeploy.error=Error uninstalling this module. The operation cannot be completed successfully.
 serverSettings.manageModules.module.unresolvedDependencies=This module cannot be started as its dependencies ({0}) are not present.


### PR DESCRIPTION
change label when module is stopped, as the live content will no longer be available. This is used when javascript-module-engine is stopped

task https://github.com/Jahia/javascript-modules/issues/241