### PR TITLE
chore: Prepare 2.8.x maintenance branch

### DIFF
--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: jahia/jahia-modules-action/sonar-analysis@v2
         with:
-          primary_release_branch: master
+          primary_release_branch: 2_8_x
           github_pr_id: ${{github.event.number}}
           sonar_url: ${{ secrets.SONAR_URL }}
           sonar_token: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -1,12 +1,12 @@
 # This workflow is triggered every time a change is pushed to any branches
 # Github actions command reference: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
-name: On merge to master
+name: On merge to 2_8_x
 
 # The workflow could also be triggered on PRs
 on:
   push:
     branches:
-      - 'master'
+      - '2_8_x'
     tags-ignore:
       - '**'
 
@@ -83,7 +83,7 @@ jobs:
   publish:
     name: Publish module
     needs: build
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/2_8_x'
     runs-on: ubuntu-latest
     env:
       NEXUS_INTERNAL_URL: https://devtools.jahia.com/nexus/content/groups/internal/

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -39,7 +39,7 @@ jobs:
           NEXUS_INTERNAL_URL: https://devtools.jahia.com/nexus/content/groups/internal/
         with:
           github_slug: Jahia/module-manager
-          primary_release_branch: master
+          primary_release_branch: 2_8_x
           release_id: ${{ github.event.release.id }}
           release_version: ${{ github.event.release.tag_name }}
           github_api_token: ${{ secrets.GH_API_TOKEN }}

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -7,64 +7,8 @@ on:
     types: [prereleased]
 
 jobs:
-  on-release:
-    runs-on: ubuntu-latest
-
-    # The cimg-mvn-cache is an image containing a .m2 folder warmed-up
-    # with common Jahia dependencies. Using this prevents maven from
-    # downloading the entire world when building.
-    # More on https://github.com/Jahia/cimg-mvn-cache
-    container:
-      image: jahia/cimg-mvn-cache:ga_cimg_openjdk_8.0.312-node
-      credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-    steps:
-      # Providing the SSH PRIVATE of a user part of an admin group
-      # is necessary to bypass PR checks
-      - uses: actions/checkout@v3
-        with:
-          ssh-key: ${{ secrets.GH_SSH_PRIVATE_KEY_JAHIACI }}
-
-      # Setting up the SSH agent to be able to commit back to the repository
-      # https://github.com/webfactory/ssh-agent
-      - uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: ${{ secrets.GH_SSH_PRIVATE_KEY_JAHIACI }}
-
-      - uses: jahia/jahia-modules-action/release@v2
-        name: Release Module
-        env:
-          NEXUS_INTERNAL_URL: https://devtools.jahia.com/nexus/content/groups/internal/
-        with:
-          github_slug: Jahia/module-manager
-          primary_release_branch: 2_8_x
-          release_id: ${{ github.event.release.id }}
-          release_version: ${{ github.event.release.tag_name }}
-          github_api_token: ${{ secrets.GH_API_TOKEN }}
-          nexus_username: ${{ secrets.NEXUS_USERNAME }}
-          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-
-      - uses: jahia/jahia-modules-action/update-signature@v2
-        with:
-          nexus_username: ${{ secrets.NEXUS_USERNAME }}
-          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-          nexus_enterprise_releases_url: ${{ secrets.NEXUS_ENTERPRISE_RELEASES_URL }}
-          force_signature: true
-
-      - uses: jahia/jahia-modules-action/release-publication@v2
-        name: Publish Module
-        with:
-          module_id: module-manager
-          release_version: ${{ github.event.release.tag_name }}
-          nexus_username: ${{ secrets.NEXUS_USERNAME }}
-          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-
-      # Tmate only starts if any of the previous steps fails.
-      # Be careful since it also means that if a step fails the workflow will
-      # keep running until it reaches the timeout
-      - name: Setup tmate session
-        if: ${{ failure() }}
-        uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 15
+  release-module:
+    uses: Jahia/jahia-modules-action/.github/workflows/release-module.yml@v2
+    secrets: inherit
+    with:
+      primary_release_branch: "2_8_x"

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.jahia.modules</groupId>
         <artifactId>module-manager-parent</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.8.1-SNAPSHOT</version>
     </parent>
     <artifactId>module-manager</artifactId>
     <packaging>bundle</packaging>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.jahia.modules</groupId>
         <artifactId>module-manager-parent</artifactId>
-        <version>2.8.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
     <artifactId>module-manager</artifactId>
     <packaging>bundle</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <relativePath />
     </parent>
     <artifactId>module-manager-parent</artifactId>
-    <version>2.8.0</version>
+    <version>2.8.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Module Manager Parent</name>
     <description>DX Module Management module</description>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <relativePath />
     </parent>
     <artifactId>module-manager-parent</artifactId>
-    <version>2.8.0-SNAPSHOT</version>
+    <version>2.8.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Module Manager Parent</name>
     <description>DX Module Management module</description>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     </scm>
 
     <properties>
-        <jahia-module-signature>MCwCFBVARiD9ohyYpRNIZU/uO6tROaVDAhRPR2JyObSmsLmWd66lSlp0/Ud3oA==</jahia-module-signature>
+        <jahia-module-signature>MC0CFQCGTOyAgUlmCR1m5j+O84H+P2CvKgIUTKFB5VLyDM4tgRvnR9MOXYIy6f8=</jahia-module-signature>
     </properties>
 
     <repositories>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.jahia.modules</groupId>
         <artifactId>module-manager-parent</artifactId>
-        <version>2.8.0</version>
+        <version>2.8.0-SNAPSHOT</version>
     </parent>
     <artifactId>module-manager-test</artifactId>
     <groupId>org.jahia.test</groupId>
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.jahia.modules</groupId>
             <artifactId>module-manager</artifactId>
-            <version>2.8.0</version>
+            <version>2.8.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.jahia.modules</groupId>
         <artifactId>module-manager-parent</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.8.1-SNAPSHOT</version>
     </parent>
     <artifactId>module-manager-test</artifactId>
     <groupId>org.jahia.test</groupId>
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.jahia.modules</groupId>
             <artifactId>module-manager</artifactId>
-            <version>2.8.0-SNAPSHOT</version>
+            <version>2.8.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Closes https://github.com/Jahia/jahia-private/issues/4028.

### Description
Prepare the 2.8.x maintenance branch created from https://github.com/Jahia/module-manager/tree/2_8_0.
This maintenance branch is intended to be used for Jahia 8.1.x.

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
