### PR TITLE
ci: Fix reusable workflow

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release-module:
-    uses: Jahia/jahia-modules-action/.github/workflows/release-module.yml@v2
-    secrets: inherit 
+    uses: Jahia/jahia-modules-action/.github/workflows/reusable-release-module.yml@v2
+    secrets: inherit
     with:
       primary_release_branch: "master"


### PR DESCRIPTION
### Description
Use the reusable workflow for the release process.
The existing workflow is broken, see https://github.com/Jahia/module-manager/actions/runs/16411674166/workflow:
```
GitHub Actions
/ .github/workflows/on-release.yml
Invalid workflow file

error parsing called workflow
".github/workflows/on-release.yml"
-> "Jahia/jahia-modules-action/.github/workflows/release-module.yml@v2"
: failed to fetch workflow: workflow was not found.
```

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
