### PR TITLE
fix: render the modules administration screen only for server administrators

### DIFF
--- a/.chachalog/Wj6MCwgI.md
+++ b/.chachalog/Wj6MCwgI.md
@@ -1,0 +1,5 @@
+---
+module-manager: patch
+---
+
+Render the modules administration screen only for server administrators

--- a/core/src/main/resources/jnt_serverSettingsManageModules/html/serverSettingsManageModules.properties
+++ b/core/src/main/resources/jnt_serverSettingsManageModules/html/serverSettingsManageModules.properties
@@ -1,0 +1,12 @@
+# This screen is an ordinary, instantiable content type, so the server administration container it was
+# designed for is not the only place it can be rendered from. The permission requirement declared on the
+# settings template that hosts it (j:requiredPermissionNames=adminTemplates) is a property of that
+# template, so the same component rendered through any other resource — a plain page content area —
+# would carry no requirement and its web flow would be handed to whoever can render that resource.
+# Declaring it here makes the requirement a property of the component, on every render path.
+#
+# `admin` rather than the finer `adminTemplates`: `admin` ships in core (root-permissions.xml) and is what
+# the server-administrator role grants, whereas module-contributed permissions resolve to false
+# indistinguishably from a denial on an instance where they are not registered — which would fail closed
+# for administrators too. The finer requirement still applies on the administration route via the template.
+requirePermissions=admin

--- a/core/src/main/resources/jnt_serverSettingsManageModules/html/serverSettingsManageModules.properties
+++ b/core/src/main/resources/jnt_serverSettingsManageModules/html/serverSettingsManageModules.properties
@@ -1,12 +1,10 @@
-# This screen is an ordinary, instantiable content type, so the server administration container it was
-# designed for is not the only place it can be rendered from. The permission requirement declared on the
-# settings template that hosts it (j:requiredPermissionNames=adminTemplates) is a property of that
-# template, so the same component rendered through any other resource — a plain page content area —
-# would carry no requirement and its web flow would be handed to whoever can render that resource.
-# Declaring it here makes the requirement a property of the component, on every render path.
+# The permission requirement belongs on the component, not only on the settings template that normally
+# hosts it: a component's access rule should travel with the component and hold on every render path,
+# regardless of where it is placed. `TemplatePermissionCheckFilter` enforces this before the view runs,
+# and it propagates to every view variant via the default view's properties.
 #
 # `admin` rather than the finer `adminTemplates`: `admin` ships in core (root-permissions.xml) and is what
-# the server-administrator role grants, whereas module-contributed permissions resolve to false
-# indistinguishably from a denial on an instance where they are not registered — which would fail closed
-# for administrators too. The finer requirement still applies on the administration route via the template.
+# the server-administrator role grants, whereas a module-contributed permission that isn't registered on an
+# instance resolves to false — which would fail closed for administrators too. The finer requirement still
+# applies on the administration route via the template.
 requirePermissions=admin


### PR DESCRIPTION
## Summary

The modules administration screen is an ordinary, instantiable content type. The permission it requires
(`adminTemplates`) is declared on the settings **template** that hosts it (`j:requiredPermissionNames`), so it
is a property of that template rather than of the component. Rendered through any other resource — a plain
page content area — the component carries no requirement at all, and the Spring web flow behind it is handed
to whoever can render that resource; the flow's handler then runs with the service-level authority it holds.

This declares the requirement on the component instead, so it holds on every render path.

## Change

One view property, `requirePermissions=admin`, next to the flow view. Core's `TemplatePermissionCheckFilter`
enforces it before the view executes, and the property propagates to every view variant of the nodetype via
the view's default properties — so the `settingsBootstrap3GoogleMaterialStyle` variant is covered by the same
file. Same mechanism, and same one-line shape, as `external-provider/vfs`'s existing
`vfsPointFactoryForm.properties`.

`admin` rather than the finer `adminTemplates`: `admin` ships in core (`root-permissions.xml`) and is what the
`server-administrator` role grants. Module-contributed permissions resolve to `false` **indistinguishably from
a denial** on an instance where they are not registered in the permission registry — which would fail closed
for administrators too. Verified: a deliberately bogus permission name behaves identically, and the server
logs `Cannot check permission adminTemplates`. The finer requirement still applies on the administration route
via the template, so this is an additional condition and never a replacement.

## Verification

Measured on 8.2.4.0-SNAPSHOT, component placed in an ordinary page content area, rendering the hosting page.
The discriminator here is not the response but **whether the flow's handler runs at all**, since this screen
currently throws on render in that context for every caller:

| caller | `flowHandler.initModules` invocations | response |
|---|---|---|
| before — any caller incl. an ordinary editor | **runs** | 42 642 bytes |
| after — ordinary editor, isolated request | **0** | 937 bytes (nothing rendered) |
| after — `root`, isolated request | 3 | unchanged |

So the privileged handler is no longer entered by a caller holding no administration permission, while `root`
still reaches it. Note `root` cannot be refused by this mechanism at all — core short-circuits permission
checks for administrators — so `root` is not a discriminating subject, which is why the handler-invocation
count is measured per isolated request.

The same mechanism was confirmed behaviourally on a screen that does render: with an equivalent one-line
property, `jnt:serverSettingsRolesAndPermissions` went from serving its flow to **every** caller
(byte-identical pages) to serving it only to `root`, with a site administrator and an ordinary editor both
refused.

## Risk notes

- **This screen's render-time exception is now unreachable for non-administrators.** It throws in
  `initModules` when rendered outside its settings container, and until now that crash was the only thing
  limiting the screen there. Anyone fixing that exception should know the gate is what protects it, not the
  crash — the two were previously coupled.
- Studio rendering is not special-cased: core skips its own permission checks in `studiomode`, this property
  does not. A template developer previewing the component in studio without an administration permission will
  now get an empty fragment.
